### PR TITLE
Bridge domain edits to shared universe state

### DIFF
--- a/src/components/Project.tsx
+++ b/src/components/Project.tsx
@@ -11,14 +11,15 @@ import {
 import ProjectDetailsForm from "./forms/ProjectDetailsForm";
 import ModellingHeaderButtons from "./utils/ModellingHeaderButtons";
 import { get } from 'http';
-import { selectSharedUniverseState } from '../sharedUniverse';
+import { bindLegacyUniverseDispatch, selectSharedUniverseState } from '../sharedUniverse';
 
 const debug = false;
 
 const Project = (props) => {
 
 
-  const dispatch = useDispatch();
+  const rawDispatch = useDispatch();
+  const dispatch = bindLegacyUniverseDispatch(rawDispatch);
   const projectModalRef = useRef(null);
   const router = useRouter();
   // const modeldata = useSelector((state: { phData: { metis: { models: any[], name: string, description: string } } }) => state);

--- a/src/components/loadModelData/ProjectMenuBar.tsx
+++ b/src/components/loadModelData/ProjectMenuBar.tsx
@@ -39,7 +39,6 @@ export const ProjectMenuBar = (props: any) => {
     const router = useRouter(); // Initialize router
     if (!props.phData) return null;
     const project = props.phData.metis;
-    const domain = props.phData.domain;
     const source = props.phSource;
     const activeMetisScope = normalizeMetisScope(getWorkspaceSnapshotMeta(props.phUser)?.activeMetisScope);
     const metisScopeOptions = getMetisScopeOptions();

--- a/src/sharedUniverse/legacyDispatch.ts
+++ b/src/sharedUniverse/legacyDispatch.ts
@@ -1,6 +1,7 @@
 import type { AnyAction, Dispatch } from '@reduxjs/toolkit';
 import {
     loadLegacyUniverseSnapshot,
+    setUniverseDomain,
     setUniverseFocus,
     setUniversePhData,
     setUniverseSource,
@@ -22,6 +23,8 @@ export const toSharedUniverseAction = (action: AnyAction): AnyAction => {
             return setUniverseUser(action.data) as AnyAction;
         case 'LOAD_TOSTORE_PHSOURCE':
             return setUniverseSource(action.data) as AnyAction;
+        case 'UPDATE_DOMAIN_PROPERTIES':
+            return setUniverseDomain(action.data) as AnyAction;
         default:
             return action;
     }

--- a/src/sharedUniverse/universeSlice.ts
+++ b/src/sharedUniverse/universeSlice.ts
@@ -44,6 +44,24 @@ export type LegacyUniverseSnapshot = {
 
 const EMPTY_DOCUMENTS: unknown[] = [];
 
+const mergeDomainPatch = (domain: unknown, patch: unknown) => {
+    if (
+        domain &&
+        patch &&
+        typeof domain === 'object' &&
+        typeof patch === 'object' &&
+        !Array.isArray(domain) &&
+        !Array.isArray(patch)
+    ) {
+        return {
+            ...(domain as Record<string, unknown>),
+            ...(patch as Record<string, unknown>),
+        };
+    }
+
+    return patch;
+};
+
 export const initialUniverseState: SharedUniverseState = {
     world: {
         worldDefinition: {
@@ -87,6 +105,7 @@ export const loadLegacyUniverseSnapshot = (snapshot: LegacyUniverseSnapshot) =>
 
 export const setUniverseState = createAction<SharedUniverseState>('universe/setUniverseState');
 export const setUniversePhData = createAction<LegacyPhData>('universe/setUniversePhData');
+export const setUniverseDomain = createAction<unknown>('universe/setUniverseDomain');
 export const setUniverseUser = createAction<unknown>('universe/setUniverseUser');
 export const setUniverseSource = createAction<unknown>('universe/setUniverseSource');
 export const setUniverseFocus = createAction<unknown>('universe/setUniverseFocus');
@@ -118,6 +137,18 @@ export const universeReducer = (
             compatibility: {
                 ...state.compatibility,
                 documents,
+            },
+        };
+    }
+    if (setUniverseDomain.match(action)) {
+        return {
+            ...state,
+            world: {
+                ...state.world,
+                worldDefinition: {
+                    ...state.world.worldDefinition,
+                    domain: mergeDomainPatch(state.world.worldDefinition.domain, action.payload),
+                },
             },
         };
     }


### PR DESCRIPTION
## Summary

This follow-up slice keeps the domain migration moving after PR #14.

It bridges `UPDATE_DOMAIN_PROPERTIES` through the shared universe adapter so edits to project/domain details update `state.universe.world.worldDefinition.domain` as well as the legacy `phData.domain` reducer path.

## Changes

- Added `setUniverseDomain` to the shared universe reducer.
- Mapped legacy `UPDATE_DOMAIN_PROPERTIES` through `toSharedUniverseAction`.
- Wrapped the `Project` component dispatch with `bindLegacyUniverseDispatch` so domain edits reach shared state.
- Removed an unused `props.phData.domain` read from `ProjectMenuBar`.

## Notes

The legacy reducer still owns compatibility updates to `phData.domain`. This PR only ensures the shared universe tree remains synchronized during domain edits.

Remaining expected legacy references are compatibility paths in:

- `src/reducers/reducer.js`
- `src/components/utils/workspaceUniverseAdapter.ts`

## Validation

- `npm run build`
- `npm test`
- Local browser smoke check: `/project` loaded successfully on `localhost:3000`, showed the domain UI, and browser console had no errors.
