### PR TITLE
Remove dead legacy selectors from static surfaces

### DIFF
--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -2,9 +2,9 @@
 // Index.tsx
 
 // import React from "react";
-import React, { useState, useEffect } from "react";
+import React from "react";
 import Link from 'next/link';
-import { connect, useSelector, useDispatch } from 'react-redux';
+import { connect } from 'react-redux';
 import {
   CardGroup, Card, CardImg, CardText, CardBody, CardHeader,
   CardTitle, CardSubtitle, Button, CardLink, CardDeck, CardColumns
@@ -14,16 +14,6 @@ import Index from "./Index";
 
 const page = (props) => {
   // console.log('12', props);
-  const dispatch = useDispatch()
-  const [refresh, setRefresh] = useState(true)
-  function toggleRefresh() { setRefresh(!refresh); }
-
-  const metis = useSelector((state: any) => state.phData?.metis)
-  const models = useSelector((state: any) => state.phData?.metis?.models)
-  const metamodels = useSelector((state: any) => state.phData?.metis?.metamodels)
-  const focusModel = useSelector((state: any) => state.phFocus?.focusModel)
-  const focusModelview = useSelector((state: any) => state.phFocus?.focusModelview)
-  const gojsmodel = useSelector((state: any) => state.phFocus?.gojsModel)
 
   // useEffect(() => {
   //   // console.log('39', gojsmodel);
@@ -269,5 +259,4 @@ const page = (props) => {
 
 }
 export default Page(connect(state => state)(page));
-
 

--- a/src/components/Index.tsx
+++ b/src/components/Index.tsx
@@ -2,9 +2,9 @@
 // Index.tsx
 
 // import React from "react";
-import React, { useState, useEffect } from "react";
+import React from "react";
 import Link from 'next/link';
-import { connect, useSelector, useDispatch } from 'react-redux';
+import { connect } from 'react-redux';
 import {
   CardGroup, Card, CardImg, CardText, CardBody, CardHeader,
   CardTitle, CardSubtitle, Button, CardLink, CardDeck, CardColumns
@@ -19,23 +19,6 @@ import Project from "../components/Project";
 
 const page = (props) => {
   // console.log('12', props);
-  const dispatch = props.dispatch
-  const [refresh, setRefresh] = useState(true)
-  // function toggleRefresh() { setRefresh(!refresh); }
-  const toggleRefresh = props.toggleRefresh
-
-  /**  * Get the state and metie from the store  */
-  const phData = useSelector((state: any) => state.phData) // Selecting the whole redux store
-  const phFocus = useSelector((state: any) => state.phFocus) // Selecting the whole redux store
-  const metis = (phData) && phData.metis
-  const models = (metis) && metis.models  // selecting the models array
-  const metamodels = (metis) && metis.metamodels
-  // console.log('26 dia',  metis);
-
-  const focusModel = useSelector(focusModel => phFocus?.focusModel)
-  const focusModelview = useSelector(focusModelview => phFocus?.focusModelview)
-
-  let gojsmodel = phFocus?.gojsModel
 
   // useEffect(() => {
   //   // console.log('39', gojsmodel);
@@ -532,5 +515,3 @@ const page = (props) => {
 
 }
 export default Page(connect(state => state)(page));
-
-


### PR DESCRIPTION
## Summary

This is a small follow-up cleanup slice after the shared universe bridge work.

It removes unused direct legacy Redux selectors from static surfaces that do not need model state.

## Changes

- Removed dead `useSelector` reads from `src/components/About.tsx`.
- Removed dead `useSelector` reads from `src/components/Index.tsx`.
- Removed now-unused React/Redux imports in those files.

## Notes

This does not change rendering behavior. The removed values were not used by the components.

## Validation

- `npm run build`
- `npm test`
- Local browser smoke check: `/about` loaded successfully on `localhost:3000` and browser console had no errors.
