### PR TITLE
Sync model mutations into shared universe state

### DIFF
--- a/src/pages/model.tsx
+++ b/src/pages/model.tsx
@@ -8,9 +8,9 @@ import { InitialState } from '../reducers/reducer';
 import { normalizeGithubSource, readShareQueryValue } from '../components/utils/focusShare';
 import { readJsonResponse, readJsonResponseError } from '../components/utils/httpResponse';
 import { buildRemoteMetisProxyPath, buildRemoteMetisResourceUri, normalizeRemoteUniverseBaseUrl, readRemoteUniverseId, readRemoteUniverseSlug } from '../components/utils/remoteUniverse';
-import { buildMimrisStateFromWorkspaceSnapshot, getWorkspaceSnapshotMeta, isWorkspaceUniverseSnapshot } from '../components/utils/workspaceUniverseAdapter';
+import { buildMimrisStateFromWorkspaceSnapshot, isWorkspaceUniverseSnapshot } from '../components/utils/workspaceUniverseAdapter';
 import { saveRemoteUniverseProject } from '../components/utils/remoteUniverseProject';
-import { describeMetisAvailability, normalizeMetisScope, setActiveMetisScope } from '../components/utils/workspaceMetisResolver.js';
+import { normalizeMetisScope, setActiveMetisScope } from '../components/utils/workspaceMetisResolver.js';
 import { buildUniverseStateFromLegacy, selectSharedUniverseState, setUniverseState, setUniverseUser } from '../sharedUniverse';
 
 const page = (props: any) => {
@@ -24,6 +24,7 @@ const page = (props: any) => {
     const [saveStatus, setSaveStatus] = useState('');
     const [visibleFocusDetails, setVisibleFocusDetails] = useState(false);
     const [exportTab, setExportTab] = useState(0);
+    const [fetchedUsername, setFetchedUsername] = useState<string | null>(null);
     const sharedUniverse = useSelector(selectSharedUniverseState);
     const phFocus = sharedUniverse.world.focus ?? props.phFocus;
     const phUser = sharedUniverse.user ?? props.phUser;
@@ -45,9 +46,6 @@ const page = (props: any) => {
     const universeName = phFocus?.focusProj?.name || '';
     const metisSuiteName = phData?.metis?.name || '';
     const headerLabel = [universeName, metisSuiteName].filter(Boolean).join(' / ');
-    const workspaceMeta = getWorkspaceSnapshotMeta(phUser);
-    const activeMetisScope = normalizeMetisScope(workspaceMeta?.activeMetisScope);
-    const metisAvailability = describeMetisAvailability(workspaceMeta?.snapshot);
     const LAST_FOCUS_MODEL_STORAGE_KEY = 'mimris.modelling.focusModelId';
 
     const normalizeModels = (items: any) => Array.isArray(items) ? items.filter(Boolean) : [];
@@ -414,7 +412,7 @@ const page = (props: any) => {
                 const username = typeof data?.username === 'string' && data.username
                     ? data.username.charAt(0).toUpperCase() + data.username.slice(1)
                     : 'Guest';
-                dispatch(setUniverseUser({ ...phUser, focusUser: { name: username } }));
+                setFetchedUsername(username);
             } catch (error) {
                 console.error('Error fetching username:', error);
             }
@@ -422,6 +420,19 @@ const page = (props: any) => {
 
         fetchUsername();
     }, []);
+
+    useEffect(() => {
+        if (!fetchedUsername) return;
+        if (phUser?.focusUser?.name === fetchedUsername) return;
+
+        dispatch(setUniverseUser({
+            ...(phUser || {}),
+            focusUser: {
+                ...(phUser?.focusUser || {}),
+                name: fetchedUsername,
+            },
+        }));
+    }, [dispatch, fetchedUsername, phUser]);
 
     useEffect(() => {
         if (!hasMounted) return;

--- a/src/sharedUniverse/universeSlice.ts
+++ b/src/sharedUniverse/universeSlice.ts
@@ -96,6 +96,89 @@ const legacyFocusFieldByActionType: Record<string, string> = {
     SET_FOCUS_REFRESH: 'focusRefresh',
 };
 
+const asRecord = (value: unknown): Record<string, any> =>
+    value && typeof value === 'object' && !Array.isArray(value)
+        ? value as Record<string, any>
+        : {};
+
+const replaceArrayItem = <T,>(items: T[], index: number, item: T) => [
+    ...items.slice(0, index),
+    item,
+    ...items.slice(index + 1),
+];
+
+const updateMetis = (
+    state: SharedUniverseState,
+    metis: unknown,
+    focus = state.world.focus,
+): SharedUniverseState => ({
+    ...state,
+    world: {
+        ...state.world,
+        worldModel: {
+            ...state.world.worldModel,
+            metis,
+        },
+        focus,
+    },
+});
+
+const findModelIndex = (
+    models: any[],
+    focus: Record<string, any>,
+    modelId?: string,
+) => {
+    const explicitIndex = modelId
+        ? models.findIndex((model) => model?.id === modelId)
+        : -1;
+    if (explicitIndex >= 0) return explicitIndex;
+
+    const focusModelId = focus?.focusModel?.id;
+    const focusIndex = focusModelId
+        ? models.findIndex((model) => model?.id === focusModelId)
+        : -1;
+
+    return focusIndex >= 0 ? focusIndex : 0;
+};
+
+const updateFocusedItem = (
+    focus: Record<string, any>,
+    field: string,
+    patch: Record<string, unknown>,
+) => {
+    const currentValue = focus?.[field];
+    if (!currentValue?.id || currentValue.id !== patch?.id) return focus;
+
+    return {
+        ...focus,
+        [field]: {
+            ...currentValue,
+            ...patch,
+        },
+    };
+};
+
+const reorderById = (items: any[], sourceId?: string, targetId?: string) => {
+    const sourceIndex = items.findIndex((item) => item?.id === sourceId);
+    const targetIndex = items.findIndex((item) => item?.id === targetId);
+    if (sourceIndex < 0 || targetIndex < 0 || sourceIndex === targetIndex) return items;
+
+    const reorderedItems = [...items];
+    const [movedItem] = reorderedItems.splice(sourceIndex, 1);
+    reorderedItems.splice(targetIndex, 0, movedItem);
+
+    return reorderedItems;
+};
+
+const sanitizeModelviewPatch = (patch: Record<string, unknown>) => {
+    const sanitizedPatch = { ...patch };
+    delete sanitizedPatch.objectviews;
+    delete sanitizedPatch.relshipviews;
+    delete sanitizedPatch.objecttypeviews;
+    delete sanitizedPatch.relshiptypeviews;
+    return sanitizedPatch;
+};
+
 export const initialUniverseState: SharedUniverseState = {
     world: {
         worldDefinition: {
@@ -231,6 +314,95 @@ export const universeReducer = (
                 focus: mergeObjectPatch(state.world.focus, { [legacyFocusField]: action.data }),
             },
         };
+    }
+    if (action.type === 'UPDATE_PROJECT_PROPERTIES') {
+        const metis = asRecord(state.world.worldModel.metis);
+        return updateMetis(state, {
+            ...metis,
+            ...asRecord(action.data),
+        });
+    }
+    if (action.type === 'UPDATE_MODEL_PROPERTIES' || action.type === 'UPDATE_TARGETMODEL_PROPERTIES') {
+        const metis = asRecord(state.world.worldModel.metis);
+        const models: any[] = Array.isArray(metis.models) ? metis.models : [];
+        if (!models.length) return state;
+
+        const patch = asRecord(action.data);
+        const modelIndex = findModelIndex(models, asRecord(state.world.focus), patch.id);
+        if (modelIndex < 0 || !models[modelIndex]) return state;
+
+        const nextModels = replaceArrayItem(models, modelIndex, {
+            ...models[modelIndex],
+            ...patch,
+        });
+        const focus = updateFocusedItem(asRecord(state.world.focus), 'focusModel', patch);
+
+        return updateMetis(state, {
+            ...metis,
+            models: nextModels,
+        }, focus);
+    }
+    if (action.type === 'REORDER_MODELS') {
+        const metis = asRecord(state.world.worldModel.metis);
+        const models: any[] = Array.isArray(metis.models) ? metis.models : [];
+        const reorderedModels = reorderById(models, action?.data?.sourceId, action?.data?.targetId);
+        if (reorderedModels === models) return state;
+
+        return updateMetis(state, {
+            ...metis,
+            models: reorderedModels,
+        });
+    }
+    if (action.type === 'UPDATE_MODELVIEW_PROPERTIES') {
+        const metis = asRecord(state.world.worldModel.metis);
+        const models: any[] = Array.isArray(metis.models) ? metis.models : [];
+        if (!models.length) return state;
+
+        const focus = asRecord(state.world.focus);
+        const modelIndex = findModelIndex(models, focus);
+        const model = models[modelIndex];
+        const modelviews: any[] = Array.isArray(model?.modelviews) ? model.modelviews : [];
+        const patch = sanitizeModelviewPatch(asRecord(action.data));
+        const modelviewIndex = patch.id
+            ? modelviews.findIndex((modelview) => modelview?.id === patch.id)
+            : -1;
+        const targetIndex = modelviewIndex >= 0 ? modelviewIndex : modelviews.length;
+        const nextModelviews = replaceArrayItem(modelviews, targetIndex, {
+            ...(modelviews[targetIndex] || {}),
+            ...patch,
+        });
+        const nextModels = replaceArrayItem(models, modelIndex, {
+            ...model,
+            modelviews: nextModelviews,
+        });
+        const nextFocus = updateFocusedItem(focus, 'focusModelview', patch);
+
+        return updateMetis(state, {
+            ...metis,
+            models: nextModels,
+        }, nextFocus);
+    }
+    if (action.type === 'REORDER_MODELVIEWS') {
+        const metis = asRecord(state.world.worldModel.metis);
+        const models: any[] = Array.isArray(metis.models) ? metis.models : [];
+        if (!models.length) return state;
+
+        const focus = asRecord(state.world.focus);
+        const modelIndex = findModelIndex(models, focus);
+        const model = models[modelIndex];
+        const modelviews: any[] = Array.isArray(model?.modelviews) ? model.modelviews : [];
+        const reorderedModelviews = reorderById(modelviews, action?.data?.sourceId, action?.data?.targetId);
+        if (reorderedModelviews === modelviews) return state;
+
+        const nextModels = replaceArrayItem(models, modelIndex, {
+            ...model,
+            modelviews: reorderedModelviews,
+        });
+
+        return updateMetis(state, {
+            ...metis,
+            models: nextModels,
+        });
     }
     return state;
 };

--- a/src/sharedUniverse/universeSlice.ts
+++ b/src/sharedUniverse/universeSlice.ts
@@ -62,6 +62,40 @@ const mergeDomainPatch = (domain: unknown, patch: unknown) => {
     return patch;
 };
 
+const mergeObjectPatch = (value: unknown, patch: Record<string, unknown>) => {
+    if (value && typeof value === 'object' && !Array.isArray(value)) {
+        return {
+            ...(value as Record<string, unknown>),
+            ...patch,
+        };
+    }
+
+    return patch;
+};
+
+const legacyFocusFieldByActionType: Record<string, string> = {
+    SET_FOCUS_TAB: 'focusTab',
+    SET_FOCUS_MODEL: 'focusModel',
+    SET_FOCUS_MODELVIEW: 'focusModelview',
+    SET_FOCUS_TARGETMETAMODEL: 'focusTargetMetamodel',
+    SET_FOCUS_TARGETMODEL: 'focusTargetModel',
+    SET_FOCUS_TARGETMODELVIEW: 'focusTargetModelview',
+    SET_FOCUS_OBJECT: 'focusObject',
+    SET_FOCUS_OBJECTVIEW: 'focusObjectview',
+    SET_FOCUS_RELSHIP: 'focusRelship',
+    SET_FOCUS_RELSHIPVIEW: 'focusRelshipview',
+    SET_FOCUS_OBJECTTYPE: 'focusObjecttype',
+    SET_FOCUS_RELSHIPTYPE: 'focusRelshiptype',
+    SET_FOCUS_PROJ: 'focusProj',
+    SET_FOCUS_ORG: 'focusOrg',
+    SET_FOCUS_ROLE: 'focusRole',
+    SET_FOCUS_COLLECTION: 'focusCollection',
+    SET_FOCUS_TASK: 'focusTask',
+    SET_FOCUS_ISSUE: 'focusIssue',
+    SET_FOCUS_SOURCE: 'focusSource',
+    SET_FOCUS_REFRESH: 'focusRefresh',
+};
+
 export const initialUniverseState: SharedUniverseState = {
     world: {
         worldDefinition: {
@@ -170,6 +204,31 @@ export const universeReducer = (
             world: {
                 ...state.world,
                 focus: action.payload,
+            },
+        };
+    }
+    if (action.type === 'SET_FOCUS_PHFOCUS') {
+        return {
+            ...state,
+            world: {
+                ...state.world,
+                focus: action.data,
+            },
+        };
+    }
+    if (action.type === 'SET_FOCUS_USER') {
+        return {
+            ...state,
+            user: mergeObjectPatch(state.user, { focusUser: action.data }),
+        };
+    }
+    const legacyFocusField = legacyFocusFieldByActionType[action.type];
+    if (legacyFocusField) {
+        return {
+            ...state,
+            world: {
+                ...state.world,
+                focus: mergeObjectPatch(state.world.focus, { [legacyFocusField]: action.data }),
             },
         };
     }

--- a/src/store.tsx
+++ b/src/store.tsx
@@ -50,8 +50,9 @@ const mirrorUniverseToLegacy = (
 const rootReducer = (state: RootReducerState | undefined, action: AnyAction): RootReducerState => {
     const legacyState = reduceLegacyState(state, action);
     const previousUniverse = state?.universe ?? buildUniverseStateFromLegacy(legacyState);
-    const nextUniverse = action.type.startsWith('universe/')
-        ? universeReducer(previousUniverse, action)
+    const reducedUniverse = universeReducer(previousUniverse, action);
+    const nextUniverse = reducedUniverse !== previousUniverse
+        ? reducedUniverse
         : buildUniverseStateFromLegacy({ ...legacyState, universe: undefined });
     const nextLegacyState = (
         setUniverseState.match(action) ||


### PR DESCRIPTION
## Summary
- Carry forward the shared focus sync and model-page review-fix commits that did not land in the previous merge.
- Mirror legacy model-suite mutation actions into `universe.world.worldModel.metis` for project/model/modelview property updates and model/modelview reordering.
- Keep legacy reducer behavior intact so existing GoJS/AKMM dispatch paths continue to work while shared selectors stay current.

## Verification
- `npm run build` passed.
- `npm test` passed.

## Notes
- This intentionally does not migrate object, objectview, relationship, or relationship-view mutations yet. Those are the next, larger GoJS/AKMM write-path slice.