### PR TITLE
Sync remaining metamodel collections into shared universe state

### DIFF
--- a/src/sharedUniverse/universeSlice.ts
+++ b/src/sharedUniverse/universeSlice.ts
@@ -711,5 +711,32 @@ export const universeReducer = (
     if (action.type === 'UPDATE_VIEWSTYLE_PROPERTIES') {
         return updateMetamodelCollection(state, 'current', 'viewstyles', asRecord(action.data));
     }
+    if (action.type === 'UPDATE_PROPERTY_PROPERTIES') {
+        return updateMetamodelCollection(state, 'current', 'properties', asRecord(action.data));
+    }
+    if (action.type === 'UPDATE_TARGETPROPERTY_PROPERTIES') {
+        return updateMetamodelCollection(state, 'target', 'properties', asRecord(action.data));
+    }
+    if (action.type === 'UPDATE_DATATYPE_PROPERTIES') {
+        return updateMetamodelCollection(state, 'target', 'datatypes', asRecord(action.data));
+    }
+    if (action.type === 'UPDATE_TARGETDATATYPE_PROPERTIES') {
+        return updateMetamodelCollection(state, 'target', 'datatypes', asRecord(action.data));
+    }
+    if (action.type === 'UPDATE_METHOD_PROPERTIES') {
+        return updateMetamodelCollection(state, 'current', 'methods', asRecord(action.data));
+    }
+    if (action.type === 'UPDATE_TARGETMETHOD_PROPERTIES') {
+        return updateMetamodelCollection(state, 'target', 'methods', asRecord(action.data));
+    }
+    if (action.type === 'UPDATE_METHODTYPE_PROPERTIES') {
+        return updateMetamodelCollection(state, 'target', 'methodtypes', asRecord(action.data));
+    }
+    if (action.type === 'UPDATE_VALUE_PROPERTIES') {
+        return updateMetamodelCollection(state, 'current', 'objecttypes', asRecord(action.data));
+    }
+    if (action.type === 'UPDATE_TARGETVALUE_PROPERTIES') {
+        return updateMetamodelCollection(state, 'current', 'objecttypes', asRecord(action.data));
+    }
     return state;
 };


### PR DESCRIPTION
## Summary
- Mirror the remaining metamodel collection mutation actions into `universe.world.worldModel.metis`.
- Added shared reducer handling for current/target properties, datatypes, methods, method types, and value actions.
- Kept the legacy reducer and action names intact so existing GoJS/AKMM paths continue to work while shared selectors stay current.

## Verification
- `npm run build` passed.
- `npm test` passed.

## Notes
- This follows the existing legacy reducer behavior, including legacy value actions updating object type collections.