### PR TITLE
Read modelling surface directly from shared universe selector

### DIFF
--- a/src/components/Modelling.tsx
+++ b/src/components/Modelling.tsx
@@ -105,13 +105,13 @@ const Modelling = (props: any) => {
   // const [visibleFocusDetails, setVisibleFocusDetails] = useState(true) // show/hide the focus details (right side)
 
   const sharedUniverse = useSelector(selectSharedUniverseState);
-  const metis = sharedUniverse.world.worldModel.metis ?? props.phData?.metis;
-  const phFocus = sharedUniverse.world.focus ?? props.phFocus;
-  const phUser = sharedUniverse.user ?? props.phUser;
-  const phSource = sharedUniverse.source ?? props.phSource;
+  const metis = sharedUniverse.world.worldModel.metis as any;
+  const phFocus = sharedUniverse.world.focus as any;
+  const phUser = sharedUniverse.user as any;
+  const phSource = sharedUniverse.source as any;
   const phData = useMemo(() => ({
     ...props.phData,
-    domain: sharedUniverse.world.worldDefinition.domain ?? props.phData?.domain,
+    domain: sharedUniverse.world.worldDefinition.domain,
     metis,
   }), [props.phData, sharedUniverse.world.worldDefinition.domain, metis]);
   const compatibilityProps = useMemo(() => ({

--- a/src/pages/model.tsx
+++ b/src/pages/model.tsx
@@ -26,15 +26,15 @@ const page = (props: any) => {
     const [exportTab, setExportTab] = useState(0);
     const [fetchedUsername, setFetchedUsername] = useState<string | null>(null);
     const sharedUniverse = useSelector(selectSharedUniverseState);
-    const phFocus = sharedUniverse.world.focus ?? props.phFocus;
-    const phUser = sharedUniverse.user ?? props.phUser;
-    const phSource = sharedUniverse.source ?? props.phSource;
-    const metis = sharedUniverse.world.worldModel.metis ?? props.phData?.metis;
+    const phFocus = sharedUniverse.world.focus as any;
+    const phUser = sharedUniverse.user as any;
+    const phSource = sharedUniverse.source as any;
+    const metis = sharedUniverse.world.worldModel.metis as any;
     const phData = useMemo(() => ({
         ...props.phData,
-        domain: sharedUniverse.world.worldDefinition.domain ?? props.phData?.domain,
+        domain: sharedUniverse.world.worldDefinition.domain,
         metis,
-        documents: sharedUniverse.compatibility.documents ?? props.phData?.documents,
+        documents: sharedUniverse.compatibility.documents,
     }), [props.phData, sharedUniverse.world.worldDefinition.domain, sharedUniverse.compatibility.documents, metis]);
     const compatibilityProps = useMemo(() => ({
         ...props,


### PR DESCRIPTION
## Summary
- Remove redundant component-level `?? props.ph*` fallbacks in `/model` and `Modelling`.
- Rely on `selectSharedUniverseState` as the fallback-aware read boundary for legacy `ph*` compatibility.
- Keep the legacy-shaped compatibility props passed to downstream GoJS/AKMM components.

## Verification
- `npm test` passed: 9 tests.
- `npm run build` passed.

## Notes
- This is intentionally narrow cleanup. It does not remove the legacy reducer or downstream compatibility props yet.