### PR TITLE
Pass shared universe data through leaf surfaces

### DIFF
--- a/src/components/Project.tsx
+++ b/src/components/Project.tsx
@@ -23,9 +23,19 @@ const Project = (props) => {
   const projectModalRef = useRef(null);
   const router = useRouter();
   // const modeldata = useSelector((state: { phData: { metis: { models: any[], name: string, description: string } } }) => state);
-  const modeldata = props.props;
   const sharedUniverse = useSelector(selectSharedUniverseState);
   const domain = sharedUniverse.world.worldDefinition.domain || {};
+  const modeldata = {
+    ...props.props,
+    phData: {
+      ...props.props?.phData,
+      domain,
+      metis: sharedUniverse.world.worldModel.metis,
+    },
+    phFocus: sharedUniverse.world.focus,
+    phUser: sharedUniverse.user,
+    phSource: sharedUniverse.source,
+  };
 
   if (debug) console.log('25 Tasks props', modeldata?.phData, props);
 
@@ -145,7 +155,7 @@ const Project = (props) => {
       className={`projectModalOpen ${!projectModalOpen ? "d-block" : "d-none"}`} style={{ marginLeft: "200px", marginTop: "100px", backgroundColor: "#fee", zIndex: "9999" }} ref={projectModalRef}>
       <Modal.Header closeButton>Set Context: </Modal.Header>
       <Modal.Body >
-        <ProjectDetailsForm props={props.props} onSubmit={handleSubmit} />
+        <ProjectDetailsForm props={modeldata} onSubmit={handleSubmit} />
       </Modal.Body>
       <Modal.Footer>
         <Button color="link" onClick={handleCloseProjectModal} >Exit</Button>

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -52,7 +52,12 @@ const page = (props:any) => {
   let myGoModel = props.phMyGoModel?.myGoModel
   let myGoMetamodel = props.phMyGoMetamodel?.myGoMetamodel
   //let myGoMetamodel = props.phGojs?.gojsMetamodel
-  let phData = { ...props.phData, metis }
+  const compatibilityProps = {
+    ...props,
+    phData: { ...props.phData, metis },
+    phFocus,
+    phSource,
+  }
 
   const models = metis?.models
   const focusModelId = focusModel?.id
@@ -105,7 +110,7 @@ const page = (props:any) => {
             <Row >
               <Col style={{ paddingLeft: "1px", marginLeft: "1px" }}>
                 <div className="myModeller mb-1 pl-1 pr-1" style={{ backgroundColor: "#ddd", width: "100%", height: "101%", border: "solid 1px black" }}>
-                   <ObjectTable ph={props} />  
+                   <ObjectTable ph={compatibilityProps} />  
                 </div>
               </Col>
             </Row>
@@ -117,7 +122,7 @@ const page = (props:any) => {
            <Row >
               <Col style={{ paddingLeft: "1px", marginLeft: "1px" }}>
                 <div className="myModeller mb-1 pl-1 pr-1" style={{ backgroundColor: "#ddd", width: "100%", height: "101%", border: "solid 1px black" }}>
-                   <RelshipTable ph={props} />  
+                   <RelshipTable ph={compatibilityProps} />  
                 </div>
               </Col>
             </Row>
@@ -133,7 +138,7 @@ const page = (props:any) => {
   const modelType = (activeTab === '1') ? 'objects' : 'relationships'
   // const EditFocusModalMDiv = (focusRelshipview?.name || focusRelshiptype?.name) && <EditFocusModal buttonLabel='Mod' className='ContextModal' modelType={'modelview'} ph={props} refresh={refresh} setRefresh={setRefresh} />
   // const EditFocusModalDiv = <EditFocusModal buttonLabel='Edit' className='ContextModal' modelType={modelType} ph={props} refresh={refresh} setRefresh={setRefresh} />
-  const EditFocusModalODiv = (focusObjectview?.name || focusObjecttype?.name ) && <EditFocusModal buttonLabel='Obj' className='ContextModal' modelType={modelType} ph={props} refresh={refresh} setRefresh={setRefresh} />
+  const EditFocusModalODiv = (focusObjectview?.name || focusObjecttype?.name ) && <EditFocusModal buttonLabel='Obj' className='ContextModal' modelType={modelType} ph={compatibilityProps} refresh={refresh} setRefresh={setRefresh} />
   // const EditFocusModalRDiv = (focusRelshipview?.name || focusRelshiptype?.name) && <EditFocusModal buttonLabel='Rel' className='ContextModal' modelType={modelType} ph={props} refresh={refresh} setRefresh={setRefresh} />
     // : (focusObjectview.name) && <EditFocusMetamodel buttonLabel='Edit' className='ContextModal' ph={props} refresh={refresh} setRefresh={setRefresh} />
   if (debug) console.log('134 Table', props, curmod);


### PR DESCRIPTION
## Summary
- Route `Table` child table/edit props through shared-universe-derived compatibility props.
- Route `Project` display and project details form data through shared-universe-derived `modeldata`.
- Keep downstream legacy prop shapes intact while reducing direct dependency on stale connected `ph*` props.

## Verification
- `npm test` passed: 9 tests.
- `npm run build` passed.

## Notes
- `Tasks` already reads from the shared selector for its main model/focus data, so it was left unchanged in this slice.