### PR TITLE
Normalize shared universe objectview identities

### DIFF
--- a/src/reducers/reducer.js
+++ b/src/reducers/reducer.js
@@ -94,6 +94,7 @@ import {
   SET_VISIBLE_CONTEXT,
   UPDATE_DOMAIN_PROPERTIES,
 } from '../actions/types';
+import { normalizeModelviewObjectviewIdentities } from '../sharedUniverse/universeSlice';
 
 //import context from '../pages/context';
 
@@ -268,7 +269,10 @@ function reducer(state = InitialState, action) {
       // if (debug) console.log('160 LOAD_DATA_SUCCESS', action);
       return {
         ...state,
-        phData: action.data,
+        phData: {
+          ...action.data,
+          metis: normalizeModelviewObjectviewIdentities(action.data?.metis),
+        },
         phSource: 'Model server'
       }
     case LOAD_DATAGITHUB_SUCCESS:
@@ -276,7 +280,10 @@ function reducer(state = InitialState, action) {
       const retval_LOAD_DATAGITHUB_SUCCESS =
       {
         ...state,
-        phData: action.data.data.phData,
+        phData: {
+          ...action.data.data.phData,
+          metis: normalizeModelviewObjectviewIdentities(action.data.data.phData?.metis),
+        },
         phSource: action.data.data.phSource, //'GitHub'
         phFocus: action.data.data.phFocus,
         phUser: action.data.data.phUser,
@@ -336,7 +343,7 @@ function reducer(state = InitialState, action) {
           ...action.data,
           metis: {
             ...state.phData.metis,
-            ...action.data.metis
+            ...normalizeModelviewObjectviewIdentities(action.data.metis)
           } 
         }
       }
@@ -367,10 +374,12 @@ function reducer(state = InitialState, action) {
         phData: {
           ...state.phData,
           metis: {
-            ...state.phData.metis,
-            models: [
-              ...state.phData.metis.models, action.data
-            ]
+            ...normalizeModelviewObjectviewIdentities({
+              ...state.phData.metis,
+              models: [
+                ...state.phData.metis.models, action.data
+              ]
+            })
           },
           domain: {
             ...state.phData.domain,
@@ -390,12 +399,14 @@ function reducer(state = InitialState, action) {
         phData: {
           ...state.phData,
           metis: {
-            ...state.phData.metis,
-            models: [
-              ...state.phData.metis.models.slice(0, curmindexnew),
-              action.data,
-              ...state.phData.metis.models.slice(curmindexnew + 1, state.phData?.metis?.models.length),
-            ]
+            ...normalizeModelviewObjectviewIdentities({
+              ...state.phData.metis,
+              models: [
+                ...state.phData.metis.models.slice(0, curmindexnew),
+                action.data,
+                ...state.phData.metis.models.slice(curmindexnew + 1, state.phData?.metis?.models.length),
+              ]
+            })
           }
         }
       }

--- a/src/sharedUniverse/universeSlice.test.mjs
+++ b/src/sharedUniverse/universeSlice.test.mjs
@@ -27,7 +27,7 @@ const loadUniverseSlice = () => {
   return module.exports;
 };
 
-const { universeReducer } = loadUniverseSlice();
+const { universeReducer, normalizeModelviewObjectviewIdentities, setUniversePhData } = loadUniverseSlice();
 
 const createState = () => ({
   world: {
@@ -125,6 +125,72 @@ test('GoJS objectview mutations update shared modelview collections', () => {
   assert.equal(objectview.name, 'Renamed object view');
   assert.equal(objectview.strokecolor, 'red');
   assert.equal('fillcolor' in objectview, false);
+});
+
+test('normalizes generated modelviews so shared objects have distinct objectview ids', () => {
+  const metis = {
+    models: [
+      {
+        id: 'model-1',
+        objects: [{ id: 'object-1', name: 'Object 1' }],
+        modelviews: [
+          {
+            id: 'view-1',
+            objectviews: [{ id: 'object-1', objectRef: 'object-1', loc: '0 0' }],
+            relshipviews: [],
+          },
+          {
+            id: 'view-2',
+            objectviews: [
+              { id: 'object-1', objectRef: 'object-1', loc: '100 100' },
+              { id: 'object-2', objectRef: 'object-2', loc: '200 200' },
+            ],
+            relshipviews: [
+              {
+                id: 'rv-1',
+                fromobjviewRef: 'object-1',
+                toobjviewRef: 'object-2',
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+
+  const normalized = normalizeModelviewObjectviewIdentities(metis);
+  const [view1, view2] = normalized.models[0].modelviews;
+
+  assert.equal(view1.objectviews[0].objectRef, 'object-1');
+  assert.equal(view2.objectviews[0].objectRef, 'object-1');
+  assert.notEqual(view1.objectviews[0].id, 'object-1');
+  assert.notEqual(view2.objectviews[0].id, 'object-1');
+  assert.notEqual(view1.objectviews[0].id, view2.objectviews[0].id);
+  assert.equal(view2.relshipviews[0].fromobjviewRef, view2.objectviews[0].id);
+  assert.equal(view2.relshipviews[0].toobjviewRef, view2.objectviews[1].id);
+});
+
+test('shared phData load actions normalize objectview identities', () => {
+  const nextState = universeReducer(createState(), setUniversePhData({
+    metis: {
+      models: [
+        {
+          id: 'model-1',
+          modelviews: [
+            {
+              id: 'view-1',
+              objectviews: [{ id: 'object-1', objectRef: 'object-1' }],
+            },
+          ],
+        },
+      ],
+    },
+  }));
+
+  assert.equal(
+    nextState.world.worldModel.metis.models[0].modelviews[0].objectviews[0].id,
+    'object-1-view-1',
+  );
 });
 
 test('metamodel collection mutations update current and target metamodels', () => {

--- a/src/sharedUniverse/universeSlice.ts
+++ b/src/sharedUniverse/universeSlice.ts
@@ -107,6 +107,94 @@ const replaceArrayItem = <T,>(items: T[], index: number, item: T) => [
     ...items.slice(index + 1),
 ];
 
+const makeUniqueViewId = (id: string, modelviewId: string, usedIds: Set<string>) => {
+    const baseId = id || 'objectview';
+    const scopedBaseId = `${baseId}-${modelviewId || 'modelview'}`;
+    let candidateId = scopedBaseId;
+    let index = 2;
+    while (usedIds.has(candidateId)) {
+        candidateId = `${scopedBaseId}-${index}`;
+        index += 1;
+    }
+    return candidateId;
+};
+
+export const normalizeModelviewObjectviewIdentities = (metis: unknown) => {
+    const metisRecord = asRecord(metis);
+    const models: any[] = Array.isArray(metisRecord.models) ? metisRecord.models : [];
+    if (!models.length) return metis;
+
+    let didChange = false;
+    const usedObjectviewIds = new Set<string>();
+
+    const normalizedModels = models.map((model) => {
+        const modelviews: any[] = Array.isArray(model?.modelviews) ? model.modelviews : [];
+        if (!modelviews.length) return model;
+
+        let modelDidChange = false;
+        const normalizedModelviews = modelviews.map((modelview) => {
+            const objectviews: any[] = Array.isArray(modelview?.objectviews) ? modelview.objectviews : [];
+            if (!objectviews.length) return modelview;
+
+            const idMap = new Map<string, string>();
+            let modelviewDidChange = false;
+
+            const normalizedObjectviews = objectviews.map((objectview) => {
+                const currentId = objectview?.id;
+                if (!currentId || usedObjectviewIds.has(currentId) || currentId === objectview?.objectRef) {
+                    const nextId = makeUniqueViewId(currentId, modelview?.id, usedObjectviewIds);
+                    if (currentId) idMap.set(currentId, nextId);
+                    usedObjectviewIds.add(nextId);
+                    modelviewDidChange = true;
+                    return {
+                        ...objectview,
+                        id: nextId,
+                    };
+                }
+
+                usedObjectviewIds.add(currentId);
+                return objectview;
+            });
+
+            const relshipviews: any[] = Array.isArray(modelview?.relshipviews) ? modelview.relshipviews : [];
+            const normalizedRelshipviews = idMap.size
+                ? relshipviews.map((relshipview) => {
+                    const fromobjviewRef = idMap.get(relshipview?.fromobjviewRef);
+                    const toobjviewRef = idMap.get(relshipview?.toobjviewRef);
+                    if (!fromobjviewRef && !toobjviewRef) return relshipview;
+                    modelviewDidChange = true;
+                    return {
+                        ...relshipview,
+                        ...(fromobjviewRef ? { fromobjviewRef } : {}),
+                        ...(toobjviewRef ? { toobjviewRef } : {}),
+                    };
+                })
+                : relshipviews;
+
+            if (!modelviewDidChange) return modelview;
+            modelDidChange = true;
+            didChange = true;
+            return {
+                ...modelview,
+                objectviews: normalizedObjectviews,
+                ...(Array.isArray(modelview?.relshipviews) ? { relshipviews: normalizedRelshipviews } : {}),
+            };
+        });
+
+        if (!modelDidChange) return model;
+        return {
+            ...model,
+            modelviews: normalizedModelviews,
+        };
+    });
+
+    if (!didChange) return metis;
+    return {
+        ...metisRecord,
+        models: normalizedModels,
+    };
+};
+
 const updateMetis = (
     state: SharedUniverseState,
     metis: unknown,
@@ -117,7 +205,7 @@ const updateMetis = (
         ...state.world,
         worldModel: {
             ...state.world.worldModel,
-            metis,
+            metis: normalizeModelviewObjectviewIdentities(metis),
         },
         focus,
     },
@@ -441,6 +529,7 @@ export const initialUniverseState: SharedUniverseState = {
 
 export const buildUniverseStateFromLegacy = (state?: LegacyUniverseRoot | null): SharedUniverseState => {
     const documents = Array.isArray(state?.phData?.documents) ? state.phData.documents : EMPTY_DOCUMENTS;
+    const metis = state?.universe?.world?.worldModel?.metis ?? state?.phData?.metis ?? null;
 
     return {
         world: {
@@ -448,7 +537,7 @@ export const buildUniverseStateFromLegacy = (state?: LegacyUniverseRoot | null):
                 domain: state?.universe?.world?.worldDefinition?.domain ?? state?.phData?.domain ?? null,
             },
             worldModel: {
-                metis: state?.universe?.world?.worldModel?.metis ?? state?.phData?.metis ?? null,
+                metis: normalizeModelviewObjectviewIdentities(metis),
             },
             focus: state?.universe?.world?.focus ?? state?.phFocus ?? null,
         },
@@ -474,7 +563,18 @@ export const universeReducer = (
     state: SharedUniverseState = initialUniverseState,
     action: AnyAction,
 ): SharedUniverseState => {
-    if (setUniverseState.match(action)) return action.payload;
+    if (setUniverseState.match(action)) {
+        return {
+            ...action.payload,
+            world: {
+                ...action.payload.world,
+                worldModel: {
+                    ...action.payload.world.worldModel,
+                    metis: normalizeModelviewObjectviewIdentities(action.payload.world.worldModel.metis),
+                },
+            },
+        };
+    }
     if (setUniversePhData.match(action)) {
         const payload = action.payload as LegacyPhData;
         const documents = Array.isArray(payload?.documents)
@@ -491,7 +591,9 @@ export const universeReducer = (
                 },
                 worldModel: {
                     ...state.world.worldModel,
-                    ...(payload?.metis !== undefined ? { metis: payload.metis } : {}),
+                    ...(payload?.metis !== undefined
+                        ? { metis: normalizeModelviewObjectviewIdentities(payload.metis) }
+                        : {}),
                 },
             },
             compatibility: {


### PR DESCRIPTION
## Summary
- add shared-universe normalization for generated modelview objectview ids
- rewrite relshipview endpoint refs when objectview ids are normalized
- apply normalization on shared universe load/update paths and legacy reducer load paths

## Verification
- `npm test`
- `npm run build`