### PR TITLE
Use shared universe in simple page wrappers

### DIFF
--- a/src/pages/about.tsx
+++ b/src/pages/about.tsx
@@ -1,8 +1,5 @@
 //@ts-nocheck
-// import React, { useState } from "react";
-// import { connect } from 'react-redux';
-import { connect, useDispatch } from 'react-redux';
-import { loadData } from '../actions/actions'
+import { useSelector } from 'react-redux';
 import Page from '../components/page';
 import Layout from '../components/Layout';
 import Header from "../components/Header"
@@ -10,11 +7,14 @@ import Footer from "../components/Footer"
 import About from '../components/About';
 import ContextView from '../defs/ContextView';
 import TasksHelp from '../components/TasksHelp'
+import { selectSharedUniverseState } from '../sharedUniverse';
 
-const page = (props: any) => {
+const page = () => {
 
   // console.log(props)
-  const dispatch = useDispatch()
+  const sharedUniverse = useSelector(selectSharedUniverseState);
+  const phFocus = sharedUniverse.world.focus as any;
+  const phUser = sharedUniverse.user as any;
 
   // if (!props.phData) {
   //   dispatch(loadData())
@@ -32,11 +32,11 @@ const page = (props: any) => {
   // /**
   // * Set up the Context items and link to select Context modal,
   // */
-  const setContextDiv = (props.phFocus) && <ContextView phF={props.phFocus} />
+  const setContextDiv = (phFocus) && <ContextView phF={phFocus} />
 
   return (
     <div>
-      <Layout user={props.phUser?.focusUser} >
+      <Layout user={phUser?.focusUser} >
         <div id="index" >
           <div className="wrapper">
             {/* <div className="header">
@@ -136,6 +136,5 @@ const page = (props: any) => {
 }
 
 // export default Page;
-export default Page(connect(state => state)(page));
+export default Page(page);
 // export default authenticated(Page(connect(state => state)(page)));
-

--- a/src/pages/akmm-graphql.tsx
+++ b/src/pages/akmm-graphql.tsx
@@ -1,9 +1,10 @@
 /// @ts- nocheck
 // import React, { useState } from "react";
 // import { connect, useSelector, useDispatch } from 'react-redux';
-import { connect, useSelector } from 'react-redux';
+import { useSelector } from 'react-redux';
 import Page from '../components/page';
 import Layout from '../components/Layout';
+import { selectSharedUniverseState } from '../sharedUniverse';
 // import Index from '../components/Index';
 // import { loadData } from '../actions/actions'
 // import gqlSchemas from '../components/gql/GenGqlSchemas'
@@ -28,8 +29,9 @@ const page = (props: any) => {
   // }
   // const metis = (props.phData) && props.phData.metis
   // const model = (metis) && metis.models[0]
-  const data = useSelector((state:any) => state)
-  const metis = (data.phData) && data.phData.metis
+  const sharedUniverse = useSelector(selectSharedUniverseState);
+  const metis = sharedUniverse.world.worldModel.metis as any;
+  const phUser = sharedUniverse.user as any;
   const metamodelsPre = (metis) ? JSON.stringify(metis) : []
   // console.log('22', (metis) && metis.metamodels);
   // const modelName = (metis) && metis.models[0].name
@@ -44,7 +46,7 @@ const page = (props: any) => {
 
   return (
     <div>
-      <Layout user={data.phUser?.focusUser}>
+      <Layout user={phUser?.focusUser}>
         <div>
           <h4>GraphQL Page </h4>
           
@@ -65,4 +67,4 @@ const page = (props: any) => {
   );
 }
 
-export default Page(connect(state => state)(page));
+export default Page(page);

--- a/src/pages/table.tsx
+++ b/src/pages/table.tsx
@@ -1,8 +1,6 @@
 //@ts-nocheck
-import React, { useState, useEffect } from "react";
-// import { connect } from 'react-redux';
-import { connect, useDispatch } from 'react-redux';
-import { loadData } from '../actions/actions'
+import React from "react";
+import { useSelector } from 'react-redux';
 import Page from '../components/page';
 import Layout from '../components/Layout';
 import Header from "../components/Header"
@@ -11,11 +9,16 @@ import Table from '../components/Table';
 import SetContext from '../defs/ContextView'
 import TasksHelp from '../components/TasksHelp'
 import ContextView from "../defs/ContextView";
+import { selectSharedUniverseState } from '../sharedUniverse';
 
 const debug = false;
-const page = (props: any) => {
+const page = () => {
 
-  if (debug) console.log('17', props)
+  const sharedUniverse = useSelector(selectSharedUniverseState);
+  const phFocus = sharedUniverse.world.focus as any;
+  const phUser = sharedUniverse.user as any;
+
+  if (debug) console.log('17', sharedUniverse)
   //   // const dispatch = useDispatch()
   // if (!props.phData) {
   //   dispatch(loadData())
@@ -29,7 +32,7 @@ const page = (props: any) => {
   // /**
   // * Set up the Context items and link to select Context modal,
   // */
-  const ContextDiv = (props.phFocus) && <ContextView ph={props.phFocus} />
+  const ContextDiv = (phFocus) && <ContextView ph={phFocus} />
 
   //   useEffect(() => {
   //     return () => {
@@ -39,7 +42,7 @@ const page = (props: any) => {
 
   return (
     <div>
-      <Layout user={props.phUser?.focusUser} >
+      <Layout user={phUser?.focusUser} >
         <div id="index" >
           <div className="wrapper">
             <div className="header">
@@ -140,8 +143,7 @@ const page = (props: any) => {
 }
 
 // export default Page;
-export default Page(connect(state => state)(page));
+export default Page(page);
 // // export default authenticated(Page(connect(state => state)(page)));
-
 
 

--- a/src/pages/videos.tsx
+++ b/src/pages/videos.tsx
@@ -1,8 +1,9 @@
-import { connect, useDispatch } from 'react-redux';
+import { useSelector } from 'react-redux';
 import Page from '../components/page';
 import Layout from '../components/Layout';
 import Link from 'next/link';
 import SelectVideo from '../components/SelectVideo'
+import { selectSharedUniverseState } from '../sharedUniverse';
 
 
 // import { loadData } from '../actions/actions'
@@ -10,7 +11,8 @@ import SelectVideo from '../components/SelectVideo'
 const page = (props: any) => {
 // export default function Contexts({ contexts }: any) {
 
-  const dispatch = useDispatch();
+  const sharedUniverse = useSelector(selectSharedUniverseState);
+  const phUser = sharedUniverse.user as any;
 
   // if (!props.phData) {
   //   dispatch(loadData())
@@ -19,7 +21,7 @@ const page = (props: any) => {
 
   return (
     <>
-      <Layout user={props.phUser?.focusUser} >
+      <Layout user={phUser?.focusUser} >
         <div id="video" >
           <div className="wrapper" >
             {/* <div className="header " ></div>  */}
@@ -146,7 +148,7 @@ const page = (props: any) => {
 
 }
 
-export default Page(connect(state => state)(page));
+export default Page(page);
 
                     {/* <SelectVideo />
                     <Link href="/modelling" className="nav-link text-primary ">Back</Link> */}


### PR DESCRIPTION
## Summary
- switch simple wrappers (`about`, `table`, `videos`, `akmm-graphql`) from whole-store `connect(state => state)` to `selectSharedUniverseState`
- read layout user/focus/metis data from the shared universe boundary
- remove broad Redux state injection from these pages

## Verification
- `npm test`
- `npm run build`