### PR TITLE
Avoid duplicate shared model loads

### DIFF
--- a/src/pages/model.tsx
+++ b/src/pages/model.tsx
@@ -349,13 +349,15 @@ const page = () => {
         const isWorkspaceAuthoritative = options.focusQuery?.workspaceAuthority === 'redux';
         if (isWorkspaceAuthoritative) clearStoredMemoryState();
         if (!options.preferRemote && loadMatchingRemoteMemoryState({ ...options, remoteUri })) {
-            updateModelRoute({
-                universeId: options.universeId,
-                universeSlug: options.universeSlug,
-                baseUrl: options.baseUrl,
-                metisScope: options.metisScope,
-                focusQuery: options.focusQuery,
-            });
+            if (!isWorkspaceAuthoritative) {
+                updateModelRoute({
+                    universeId: options.universeId,
+                    universeSlug: options.universeSlug,
+                    baseUrl: options.baseUrl,
+                    metisScope: options.metisScope,
+                    focusQuery: options.focusQuery,
+                });
+            }
             dispatch({
                 type: 'SET_FOCUS_REFRESH',
                 data: {
@@ -394,13 +396,15 @@ const page = () => {
                     clearStoredFocusModel();
                     if (isWorkspaceAuthoritative) clearStoredMemoryState();
                     dispatchLoadedState(fallbackState, { replaceGeometry: isWorkspaceAuthoritative });
-                    updateModelRoute({
-                        universeId: options.universeId,
-                        universeSlug: options.universeSlug,
-                        baseUrl: options.baseUrl,
-                        metisScope: options.metisScope,
-                        focusQuery: options.focusQuery,
-                    });
+                    if (!isWorkspaceAuthoritative) {
+                        updateModelRoute({
+                            universeId: options.universeId,
+                            universeSlug: options.universeSlug,
+                            baseUrl: options.baseUrl,
+                            metisScope: options.metisScope,
+                            focusQuery: options.focusQuery,
+                        });
+                    }
                     dispatch({
                         type: 'SET_FOCUS_REFRESH',
                         data: {
@@ -445,13 +449,15 @@ const page = () => {
         clearStoredFocusModel();
         if (isWorkspaceAuthoritative) clearStoredMemoryState();
         dispatchLoadedState(nextState, { replaceGeometry: isWorkspaceAuthoritative });
-        updateModelRoute({
-            universeId: options.universeId,
-            universeSlug: options.universeSlug,
-            baseUrl: options.baseUrl,
-            metisScope: options.metisScope,
-            focusQuery: options.focusQuery,
-        });
+        if (!isWorkspaceAuthoritative) {
+            updateModelRoute({
+                universeId: options.universeId,
+                universeSlug: options.universeSlug,
+                baseUrl: options.baseUrl,
+                metisScope: options.metisScope,
+                focusQuery: options.focusQuery,
+            });
+        }
         dispatch({
             type: 'SET_FOCUS_REFRESH',
             data: {


### PR DESCRIPTION
## What changed

Embedded workspace-authoritative Mimris sessions no longer rewrite their model route after loading a shared remote model. Standalone Mimris sessions keep the existing route-canonicalization behavior.

## Why

For links carrying `workspaceAuthority=redux`, the post-load route rewrite retriggered the remote-load effect. Users therefore saw `Loading shared model` twice for one workspace model.

## Impact

The embedded workspace model is loaded once while preserving current model and Modelview focus. Standalone routing behavior is unchanged.

## Validation

- `npm test` — 57 passed
- `npm run tsc -- --noEmit` — passed
- `git diff --check` — passed
- verified with the embedded BPMN model in the AI Workspace
